### PR TITLE
Require jsonfield < 3. Version 3 don't support Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         'django-appconf',
         'django-ipware',
-        'jsonfield',
+        'jsonfield<3',
         'unidecode',
         'tablib',
         'hashids',


### PR DESCRIPTION
Mateo - Agilegator